### PR TITLE
Force Secure=True on SameSite="None" cookies

### DIFF
--- a/django_samesite_none/middleware.py
+++ b/django_samesite_none/middleware.py
@@ -24,5 +24,6 @@ class SameSiteNoneMiddleware:
             for name, value in response.cookies.items():
                 if not value.get("samesite"):
                     value["samesite"] = "None"
+                    value["secure"] = True  # fixes plain set_cookie(name, value)
 
         return response


### PR DESCRIPTION
Adding this workaround since Chrome will reject non-secure cookies in the
future and many third party libs are not adjusted yet.

Resolves #1